### PR TITLE
Removing unused macros and function duplicates from <sys/time.h> (#717)

### DIFF
--- a/include/mips/config.h
+++ b/include/mips/config.h
@@ -2,8 +2,5 @@
 #define _MIPS_CONFIG_H_
 
 #define CPU_FREQ (100 * 1000 * 1000)
-#define TICKS_PER_SEC CPU_FREQ
-#define TICKS_PER_MS (CPU_FREQ / 1000)
-#define TICKS_PER_US (CPU_FREQ / (1000 * 1000))
 
 #endif /* !_MIPS_CONFIG_H_ */

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -34,12 +34,6 @@ typedef struct bintime {
   uint64_t frac; /* a fraction of second */
 } bintime_t;
 
-#define TIMEVAL(fp)                                                            \
-  (timeval_t) {                                                                \
-    .tv_sec = (long)((fp)*1000000L) / 1000000L,                                \
-    .tv_usec = (long)((fp)*1000000L) % 1000000L                                \
-  }
-
 #define _BINTIME_SEC(fp) ((time_t)(int64_t)(fp))
 #define _BINTIME_FRAC(fp) ((uint64_t)((fp - (int64_t)(fp)) * (1ULL << 63) * 2))
 
@@ -53,25 +47,8 @@ typedef struct bintime {
     .sec = 0, .frac = ((1ULL << 63) / (hz)) << 1                               \
   }
 
-static inline timeval_t st2tv(systime_t st) {
-  return (timeval_t){.tv_sec = st / 1000, .tv_usec = st % 1000};
-}
-
-static inline timeval_t ts2tv(timespec_t ts) {
-  return (timeval_t){.tv_sec = ts.tv_sec, .tv_usec = ts.tv_nsec / 1000};
-}
-
-static inline systime_t tv2st(timeval_t tv) {
-  return tv.tv_sec * 1000 + tv.tv_usec / 1000;
-}
-
 static inline systime_t bt2st(bintime_t *bt) {
   return bt->sec * 1000 + (((uint64_t)1000 * (uint32_t)(bt->frac >> 32)) >> 32);
-}
-
-static inline timeval_t bt2tv(bintime_t bt) {
-  uint32_t usec = ((uint64_t)1000000 * (uint32_t)(bt.frac >> 32)) >> 32;
-  return (timeval_t){.tv_sec = bt.sec, .tv_usec = usec};
 }
 
 /* Operations on timevals. */
@@ -99,43 +76,11 @@ static inline timeval_t bt2tv(bintime_t bt) {
     }                                                                          \
   }
 
-static inline void timeval_clear(timeval_t *tvp) {
-  *tvp = (timeval_t){.tv_sec = 0, .tv_usec = 0};
-}
-
-static inline int timeval_isset(timeval_t *tvp) {
-  return tvp->tv_sec || tvp->tv_usec;
-}
-
-#define timeval_cmp(tvp, uvp, cmp)                                             \
-  (((tvp)->tv_sec == (uvp)->tv_sec) ? (((tvp)->tv_usec)cmp((uvp)->tv_usec))    \
-                                    : (((tvp)->tv_sec)cmp((uvp)->tv_sec)))
-
-static inline timeval_t timeval_add(timeval_t *tvp, timeval_t *uvp) {
-  timeval_t res = {.tv_sec = tvp->tv_sec + uvp->tv_sec,
-                   .tv_usec = tvp->tv_usec + uvp->tv_usec};
-  if (res.tv_usec >= 1000000) {
-    res.tv_sec++;
-    res.tv_usec -= 1000000;
-  }
-  return res;
-}
-
-static inline timeval_t timeval_sub(timeval_t *tvp, timeval_t *uvp) {
-  timeval_t res = {.tv_sec = tvp->tv_sec - uvp->tv_sec,
-                   .tv_usec = tvp->tv_usec - uvp->tv_usec};
-  if (res.tv_usec < 0) {
-    res.tv_sec--;
-    res.tv_usec += 1000000;
-  }
-  return res;
-}
-
 /* Operations on bintime. */
 #define bintime_cmp(a, b, cmp)                                                 \
   (((a)->sec == (b)->sec) ? (((a)->frac)cmp((b)->frac))                        \
                           : (((a)->sec)cmp((b)->sec)))
-#define bintimeisset(bt) ((bt)->sec || (bt)->frac)
+#define bintime_isset(bt) ((bt)->sec || (bt)->frac)
 
 static inline void bintime_add_frac(bintime_t *bt, uint64_t x) {
   uint64_t old_frac = bt->frac;
@@ -190,7 +135,6 @@ typedef enum clockid { CLOCK_MONOTONIC = 1, CLOCK_REALTIME = 2 } clockid_t;
       (vsp)->tv_nsec += 1000000000L;                                           \
     }                                                                          \
   }
-#define timespec2ns(x) (((uint64_t)(x)->tv_sec) * 1000000000L + (x)->tv_nsec)
 
 /*
  * Names of the interval timers, and structure defining a timer setting.
@@ -207,19 +151,12 @@ struct itimerval {
 
 #ifdef _KERNEL
 
-/* XXX: Do not use this function, it'll get removed. */
-timeval_t get_uptime(void);
-
 /* Get high-fidelity time measured from the start of system. */
 bintime_t getbintime(void);
 
 /* System time is measured in ticks (1[ms] by default),
  * and is maintained by system clock. */
 systime_t getsystime(void);
-
-/* XXX: Do not use this function, it'll get removed.
- * Raw access to cpu internal timer. */
-timeval_t getcputime(void);
 
 int do_clock_gettime(clockid_t clk, timespec_t *tp);
 

--- a/lib/libc/sys/gettimeofday.c
+++ b/lib/libc/sys/gettimeofday.c
@@ -4,7 +4,8 @@ int gettimeofday(timeval_t *tp, void *tzp) {
   if (tp) {
     timespec_t ts;
     clock_gettime(CLOCK_REALTIME, &ts);
-    *tp = ts2tv(ts);
+    tp->tv_sec = ts.tv_sec;
+    tp->tv_usec = ts.tv_nsec / 1000;
   }
   return 0;
 }

--- a/sys/debug/struct.py
+++ b/sys/debug/struct.py
@@ -58,17 +58,6 @@ class GdbStructMeta(type):
         return super().__new__(cls, name, (GdbStructBase,) + bases, dct)
 
 
-class TimeVal(metaclass=GdbStructMeta):
-    __ctype__ = 'struct timeval'
-    __cast__ = {'tv_sec': int, 'tv_usec': int}
-
-    def as_float(self):
-        return float(self.tv_sec) + float(self.tv_usec) * 1e-6
-
-    def __str__(self):
-        return 'timeval{%.6f}' % self.as_float()
-
-
 class BinTime(metaclass=GdbStructMeta):
     __ctype__ = 'struct bintime'
     __cast__ = {'sec': int, 'frac': int}

--- a/sys/kern/clock.c
+++ b/sys/kern/clock.c
@@ -16,7 +16,8 @@ systime_t getsystime(void) {
 }
 
 static void clock_cb(timer_t *tm, void *arg) {
-  now = bintime_mul(getbintime(), SYSTIME_FREQ).sec;
+  bintime_t bin = getbintime();
+  now = bt2st(&bin);
   callout_process(now);
   sched_clock();
 }

--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -165,7 +165,3 @@ bintime_t getbintime(void) {
     return (bintime_t){0, 0};
   return tm->tm_gettime(tm);
 }
-
-timeval_t get_uptime(void) {
-  return bt2tv(getbintime());
-}

--- a/sys/mips/timer.c
+++ b/sys/mips/timer.c
@@ -59,8 +59,6 @@ static uint64_t read_count(mips_timer_state_t *state) {
   return state->count.val;
 }
 
-static inline timeval_t ticks2tv(uint64_t ticks);
-
 static void set_next_tick(mips_timer_state_t *state) {
   SCOPED_INTR_DISABLED();
   /* calculate next value of compare register based on timer period */
@@ -109,15 +107,6 @@ static bintime_t mips_timer_gettime(timer_t *tm) {
   bintime_t bt = bintime_mul(HZ2BT(CPU_FREQ), frac);
   bt.sec = sec;
   return bt;
-}
-
-static inline timeval_t ticks2tv(uint64_t ticks) {
-  ticks /= (uint64_t)TICKS_PER_US;
-  return (timeval_t){.tv_sec = ticks / 1000000LL, .tv_usec = ticks % 1000000LL};
-}
-
-timeval_t getcputime(void) {
-  return ticks2tv(read_count(state_of(&mips_timer)));
 }
 
 void mips_timer_init(void) {

--- a/sys/tests/thread_stats.c
+++ b/sys/tests/thread_stats.c
@@ -34,7 +34,7 @@ static int test_thread_stats_nop(void) {
       "Thread:%d runtime:%llu.%llu sleeptime:%llu.%llu context switches:%llu",
       i, td->td_rtime.sec, td->td_rtime.frac, td->td_slptime.sec,
       td->td_slptime.frac, td->td_nctxsw);
-    if (!bintimeisset(&td->td_rtime) && bintimeisset(&td->td_slptime))
+    if (!bintime_isset(&td->td_rtime) && bintime_isset(&td->td_slptime))
       return KTEST_FAILURE;
   }
 
@@ -84,7 +84,7 @@ static int test_thread_stats_slp(void) {
          "switches: %llu",
          i, td->td_rtime.sec, td->td_rtime.frac, td->td_slptime.sec,
          td->td_slptime.frac, td->td_nctxsw);
-    if (!bintimeisset(&td->td_rtime) || !bintimeisset(&td->td_slptime))
+    if (!bintime_isset(&td->td_rtime) || !bintime_isset(&td->td_slptime))
       return KTEST_FAILURE;
   }
   return KTEST_SUCCESS;


### PR DESCRIPTION
Co-authored-by: Krystian Bacławski <krystian.baclawski@gmail.com>